### PR TITLE
use LCE response address for memory writeback command

### DIFF
--- a/microcode/cce/ei.S
+++ b/microcode/cce/ei.S
@@ -65,7 +65,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
 complete_transfer: popq lceResp
 bi ready
 
@@ -100,7 +100,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_replacement: popq lceResp
 
 uc_inv_check: bfz uc_mem cef cmf pt
@@ -109,7 +109,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize

--- a/microcode/cce/mesi-nonspec.S
+++ b/microcode/cce/mesi-nonspec.S
@@ -90,7 +90,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
 complete_transfer: popq lceResp
 bi ready
 
@@ -130,7 +130,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_replacement: popq lceResp
 
 # Invalidate any cache with block in S
@@ -144,7 +144,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize

--- a/microcode/cce/mesi.S
+++ b/microcode/cce/mesi.S
@@ -109,7 +109,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
 complete_transfer: popq lceResp
 bi ready
 
@@ -159,7 +159,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_replacement: popq lceResp
 
 # Invalidate any cache with block in S
@@ -173,7 +173,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize

--- a/microcode/cce/moesif.S
+++ b/microcode/cce/moesif.S
@@ -136,7 +136,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
 complete_transfer: popq lceResp
 bi ready
 
@@ -192,7 +192,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_replacement: popq lceResp
 
 # Invalidate any cache with block in S
@@ -206,7 +206,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize

--- a/microcode/cce/msi-nonspec.S
+++ b/microcode/cce/msi-nonspec.S
@@ -86,7 +86,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
 complete_transfer: popq lceResp
 bi ready
 
@@ -126,7 +126,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_replacement: popq lceResp
 
 # Invalidate any cache with block in S
@@ -140,7 +140,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize

--- a/microcode/cce/msi.S
+++ b/microcode/cce/msi.S
@@ -104,7 +104,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
 complete_transfer: popq lceResp
 bi ready
 
@@ -151,7 +151,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_replacement: popq lceResp
 
 # Invalidate any cache with block in S
@@ -165,7 +165,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=req lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
 uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize


### PR DESCRIPTION
This fixes an issue with writebacks to memory generated by uncached accesses to cacheable memory. The microcode is adjusted to use the address of the writeback response from the LCE as the address for the writeback to memory issued by the CCE. This avoids a misalignment between the address of the original LCE request and the writeback response data.