### PR TITLE
remove references to Cached Exclusive Flag in MSI protocols

### DIFF
--- a/microcode/cce/msi-nonspec.S
+++ b/microcode/cce/msi-nonspec.S
@@ -134,7 +134,7 @@ uc_inv_check: bfz uc_owned_check csf pt
 inv
 
 # Invalidate and WB owner cache
-uc_owned_check: bfz uc_mem cmf cef pt
+uc_owned_check: bfz uc_mem cmf pt
 pushq lceCmd ST_WB addr=req lce=owner way=owner
 wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0

--- a/microcode/cce/msi.S
+++ b/microcode/cce/msi.S
@@ -159,7 +159,7 @@ uc_inv_check: bfz uc_owned_check csf pt
 inv
 
 # Invalidate and WB owner cache
-uc_owned_check: bfz uc_mem cmf cef pt
+uc_owned_check: bfz uc_mem cmf pt
 pushq lceCmd ST_WB addr=req lce=owner way=owner
 wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0


### PR DESCRIPTION
MSI protocol does not use the Exclusive state.