### PR TITLE
Adding additional microcode types

### DIFF
--- a/include/bp_common_bedrock_pkgdef.h
+++ b/include/bp_common_bedrock_pkgdef.h
@@ -98,9 +98,9 @@ typedef enum {
   e_bedrock_mem_rd               = 0
   ,e_bedrock_mem_wr              = 1
   ,e_bedrock_mem_amo             = 2
-  ,e_bedrock_mem_uc_rd           = 3
-  ,e_bedrock_mem_uc_wr           = 4
-  ,e_bedrock_mem_uc_amo          = 5
+  //,e_bedrock_mem_uc_rd           = 3
+  //,e_bedrock_mem_uc_wr           = 4
+  //,e_bedrock_mem_uc_amo          = 5
   ,e_bedrock_mem_pre             = 8
 } bp_bedrock_mem_type_e;
 

--- a/include/bp_common_bedrock_pkgdef.h
+++ b/include/bp_common_bedrock_pkgdef.h
@@ -97,9 +97,11 @@ typedef enum {
 typedef enum {
   e_bedrock_mem_rd               = 0
   ,e_bedrock_mem_wr              = 1
-  ,e_bedrock_mem_uc_rd           = 2
-  ,e_bedrock_mem_uc_wr           = 3
-  ,e_bedrock_mem_pre             = 4
+  ,e_bedrock_mem_amo             = 2
+  ,e_bedrock_mem_uc_rd           = 3
+  ,e_bedrock_mem_uc_wr           = 4
+  ,e_bedrock_mem_uc_amo          = 5
+  ,e_bedrock_mem_pre             = 8
 } bp_bedrock_mem_type_e;
 
 #define bp_bedrock_mem_type_width 4

--- a/microcode/cce/ei.S
+++ b/microcode/cce/ei.S
@@ -78,10 +78,10 @@ bi ready
 # Uncached Request Routine
 uncached_req: bf uc_coherent rcf
 bf uncached_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req
+pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -117,9 +117,9 @@ uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize
 bf coherent_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req wp=1
+pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
 bi ready
 

--- a/microcode/cce/mesi-nonspec.S
+++ b/microcode/cce/mesi-nonspec.S
@@ -108,10 +108,10 @@ bi ready
 # Uncached Request Routine
 uncached_req: bf uc_coherent rcf
 bf uncached_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req
+pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -152,9 +152,9 @@ uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize
 bf coherent_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req wp=1
+pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
 bi ready
 

--- a/microcode/cce/mesi.S
+++ b/microcode/cce/mesi.S
@@ -137,10 +137,10 @@ handle_pf_ucf: bf ready pf
 # Uncached Request Routine
 uncached_req: bf uc_coherent rcf
 bf uncached_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req
+pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -181,9 +181,9 @@ uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize
 bf coherent_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req wp=1
+pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
 bi ready
 

--- a/microcode/cce/moesif.S
+++ b/microcode/cce/moesif.S
@@ -170,10 +170,10 @@ handle_pf_ucf: bf ready pf
 # Uncached Request Routine
 uncached_req: bf uc_coherent rcf
 bf uncached_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req
+pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -214,9 +214,9 @@ uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize
 bf coherent_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req wp=1
+pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
 bi ready
 

--- a/microcode/cce/msi-nonspec.S
+++ b/microcode/cce/msi-nonspec.S
@@ -104,10 +104,10 @@ bi ready
 # Uncached Request Routine
 uncached_req: bf uc_coherent rcf
 bf uncached_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req
+pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -148,9 +148,9 @@ uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize
 bf coherent_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req wp=1
+pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
 bi ready
 

--- a/microcode/cce/msi.S
+++ b/microcode/cce/msi.S
@@ -129,10 +129,10 @@ handle_pf_ucf: bf ready pf
 # Uncached Request Routine
 uncached_req: bf uc_coherent rcf
 bf uncached_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req
+pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -173,9 +173,9 @@ uc_complete_inv: popq lceResp
 
 uc_mem: movgs r7 msgsize
 bf coherent_store rqf
-pushq memCmd MEM_CMD_UC_RD addr=req lce=req wp=1
+pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_UC_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
 bi ready
 

--- a/microcode/include/microcode.h
+++ b/microcode/include/microcode.h
@@ -35,9 +35,10 @@
 #define MEM_CMD_RD 0
 #define MEM_CMD_WR 1
 #define MEM_CMD_AMO 2
-#define MEM_CMD_UC_RD 3
-#define MEM_CMD_UC_WR 4
-#define MEM_CMD_UC_AMO 5
+// cacheability is controlled by PMAs
+//#define MEM_CMD_UC_RD 3
+//#define MEM_CMD_UC_WR 4
+//#define MEM_CMD_UC_AMO 5
 #define MEM_CMD_PRE 8
 
 #define SIZE_1 0

--- a/microcode/include/microcode.h
+++ b/microcode/include/microcode.h
@@ -34,9 +34,11 @@
 
 #define MEM_CMD_RD 0
 #define MEM_CMD_WR 1
-#define MEM_CMD_UC_RD 2
-#define MEM_CMD_UC_WR 3
-#define MEM_CMD_PRE 4
+#define MEM_CMD_AMO 2
+#define MEM_CMD_UC_RD 3
+#define MEM_CMD_UC_WR 4
+#define MEM_CMD_UC_AMO 5
+#define MEM_CMD_PRE 8
 
 #define SIZE_1 0
 #define SIZE_2 1


### PR DESCRIPTION
This PR adds microcode types to ucode. However, we use PMA to identify cached vs uncached, so in some respect this is not useful yet.