### PR TITLE
Specify mem_fwd data source in ucode

### DIFF
--- a/include/bp_cce_inst_pkg.h
+++ b/include/bp_cce_inst_pkg.h
@@ -265,14 +265,14 @@ typedef enum {
   ,e_opd_auto_fwd_msg                    = 0x4 // Message auto-forward control
   ,e_opd_coh_state_default               = 0x5 // Default for MSHR.next_coh_state
 
-  ,e_opd_mem_rev_v                      = 0x0
+  ,e_opd_mem_rev_v                       = 0x0
   ,e_opd_lce_resp_v                      = 0x1
   ,e_opd_pending_v                       = 0x2
   ,e_opd_lce_req_v                       = 0x3
   ,e_opd_lce_resp_type                   = 0x4
-  ,e_opd_mem_rev_type                   = 0x5
+  ,e_opd_mem_rev_type                    = 0x5
   ,e_opd_lce_resp_data                   = 0x6
-  ,e_opd_mem_rev_data                   = 0x7
+  ,e_opd_mem_rev_data                    = 0x7
   ,e_opd_lce_req_data                    = 0x8
 
 } bp_cce_inst_opd_e;
@@ -324,7 +324,7 @@ typedef enum {
   ,e_mux_sel_addr_mshr_lru               = 0x9
   ,e_mux_sel_addr_lce_req                = 0xA
   ,e_mux_sel_addr_lce_resp               = 0xB
-  ,e_mux_sel_addr_mem_rev               = 0xC
+  ,e_mux_sel_addr_mem_rev                = 0xC
   ,e_mux_sel_addr_pending                = 0xD
   ,e_mux_sel_addr_0                      = 0xF // constant 0
 } bp_cce_inst_mux_sel_addr_e;
@@ -345,7 +345,7 @@ typedef enum {
   ,e_mux_sel_lce_mshr_owner              = 0x9
   ,e_mux_sel_lce_lce_req                 = 0xA
   ,e_mux_sel_lce_lce_resp                = 0xB
-  ,e_mux_sel_lce_mem_rev                = 0xC
+  ,e_mux_sel_lce_mem_rev                 = 0xC
   ,e_mux_sel_lce_pending                 = 0xD
   ,e_mux_sel_lce_0                       = 0xF // constant 0
 } bp_cce_inst_mux_sel_lce_e;
@@ -399,7 +399,7 @@ typedef enum {
 // order: {lceReq, lceResp, memResp, pending}
 typedef enum {
   e_src_q_pending                        = 1
-  ,e_src_q_mem_rev                      = 2
+  ,e_src_q_mem_rev                       = 2
   ,e_src_q_lce_resp                      = 4
   ,e_src_q_lce_req                       = 8
 } bp_cce_inst_src_q_e;
@@ -409,7 +409,7 @@ typedef enum {
 // Source queue select
 typedef enum {
   e_src_q_sel_lce_req                    = 0x0
-  ,e_src_q_sel_mem_rev                  = 0x1
+  ,e_src_q_sel_mem_rev                   = 0x1
   ,e_src_q_sel_pending                   = 0x2
   ,e_src_q_sel_lce_resp                  = 0x3
 } bp_cce_inst_src_q_sel_e;

--- a/microcode/cce/ei.S
+++ b/microcode/cce/ei.S
@@ -44,7 +44,7 @@ pushq lceCmd ST_WB addr=lru lce=req way=lru
 replacement_poph: poph lceResp r0
 beqi r0 COH_ACK replacement_poph
 bf complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1
+pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1 src=lcerespdata
 bi next_coh_state
 complete_replacement: popq lceResp
 
@@ -66,7 +66,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1 src=lcerespdata
 bi ready
 complete_transfer: popq lceResp
 bi ready
@@ -81,7 +81,7 @@ bf uncached_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req src=lcereqdata
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -101,7 +101,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_inv_check
 uc_complete_replacement: popq lceResp
 
@@ -111,7 +111,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_mem
 uc_complete_inv: popq lceResp
 
@@ -120,6 +120,6 @@ bf coherent_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1 src=lcereqdata
 bi ready
 

--- a/microcode/cce/mesi-nonspec.S
+++ b/microcode/cce/mesi-nonspec.S
@@ -44,7 +44,7 @@ pushq lceCmd ST_WB addr=lru lce=req way=lru
 replacement_poph: poph lceResp r0
 beqi r0 COH_ACK replacement_poph
 bf complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1
+pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1 src=lcerespdata
 bi next_coh_state
 complete_replacement: popq lceResp
 
@@ -91,7 +91,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1 src=lcerespdata
 bi ready
 complete_transfer: popq lceResp
 bi ready
@@ -111,7 +111,7 @@ bf uncached_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req src=lcereqdata
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -131,7 +131,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_inv_check
 uc_complete_replacement: popq lceResp
 
@@ -146,7 +146,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_mem
 uc_complete_inv: popq lceResp
 
@@ -155,6 +155,6 @@ bf coherent_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1 src=lcereqdata
 bi ready
 

--- a/microcode/cce/mesi.S
+++ b/microcode/cce/mesi.S
@@ -58,7 +58,7 @@ pushq lceCmd ST_WB addr=lru lce=req way=lru
 replacement_poph: poph lceResp r0
 beqi r0 COH_ACK replacement_poph
 bf complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1
+pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1 src=lcerespdata
 bi next_coh_state
 complete_replacement: popq lceResp
 
@@ -110,7 +110,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1 src=lcerespdata
 bi ready
 complete_transfer: popq lceResp
 bi ready
@@ -140,7 +140,7 @@ bf uncached_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req src=lcereqdata
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -160,7 +160,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_inv_check
 uc_complete_replacement: popq lceResp
 
@@ -175,7 +175,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_mem
 uc_complete_inv: popq lceResp
 
@@ -184,6 +184,6 @@ bf coherent_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1 src=lcereqdata
 bi ready
 

--- a/microcode/cce/moesif.S
+++ b/microcode/cce/moesif.S
@@ -58,7 +58,7 @@ pushq lceCmd ST_WB addr=lru lce=req way=lru
 replacement_poph: poph lceResp r0
 beqi r0 COH_ACK replacement_poph
 bf complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1
+pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1 src=lcerespdata
 bi next_coh_state
 complete_replacement: popq lceResp
 
@@ -137,7 +137,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1 src=lcerespdata
 bi ready
 complete_transfer: popq lceResp
 bi ready
@@ -173,7 +173,7 @@ bf uncached_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req src=lcereqdata
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -193,7 +193,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_inv_check
 uc_complete_replacement: popq lceResp
 
@@ -208,7 +208,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_mem
 uc_complete_inv: popq lceResp
 
@@ -217,6 +217,6 @@ bf coherent_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1 src=lcereqdata
 bi ready
 

--- a/microcode/cce/msi-nonspec.S
+++ b/microcode/cce/msi-nonspec.S
@@ -44,7 +44,7 @@ pushq lceCmd ST_WB addr=lru lce=req way=lru
 replacement_poph: poph lceResp r0
 beqi r0 COH_ACK replacement_poph
 bf complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1
+pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1 src=lcerespdata
 bi next_coh_state
 complete_replacement: popq lceResp
 
@@ -87,7 +87,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1 src=lcerespdata
 bi ready
 complete_transfer: popq lceResp
 bi ready
@@ -107,7 +107,7 @@ bf uncached_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req src=lcereqdata
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -127,7 +127,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_inv_check
 uc_complete_replacement: popq lceResp
 
@@ -142,7 +142,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_mem
 uc_complete_inv: popq lceResp
 
@@ -151,6 +151,6 @@ bf coherent_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1 src=lcereqdata
 bi ready
 

--- a/microcode/cce/msi.S
+++ b/microcode/cce/msi.S
@@ -58,7 +58,7 @@ pushq lceCmd ST_WB addr=lru lce=req way=lru
 replacement_poph: poph lceResp r0
 beqi r0 COH_ACK replacement_poph
 bf complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1
+pushq memCmd MEM_CMD_WR addr=lru lce=req way=lru wp=1 src=lcerespdata
 bi next_coh_state
 complete_replacement: popq lceResp
 
@@ -105,7 +105,7 @@ wds addr=req lce=owner way=owner state=ownerCohSt
 transfer_poph: poph lceResp r0
 beqi r0 COH_ACK transfer_poph
 bf complete_transfer nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=owner way=owner wp=1 src=lcerespdata
 bi ready
 complete_transfer: popq lceResp
 bi ready
@@ -132,7 +132,7 @@ bf uncached_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req
 popq lceReq
 bi ready
-uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req
+uncached_store: pushq memCmd MEM_CMD_WR addr=req lce=req src=lcereqdata
 bi ready
 
 # Uncached request to coherent/cacheable memory
@@ -152,7 +152,7 @@ wds addr=req lce=req way=req state=imm COH_I
 uc_replacement_poph: poph lceResp r0
 beqi r0 COH_ACK uc_replacement_poph
 bf uc_complete_replacement nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_inv_check
 uc_complete_replacement: popq lceResp
 
@@ -167,7 +167,7 @@ wds addr=req lce=owner way=owner state=imm COH_I
 uc_inv_poph: poph lceResp r0
 beqi r0 COH_ACK uc_inv_poph
 bf uc_complete_inv nwbf
-pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1
+pushq memCmd MEM_CMD_WR addr=lceresp lce=req way=req wp=1 src=lcerespdata
 bi uc_mem
 uc_complete_inv: popq lceResp
 
@@ -176,6 +176,6 @@ bf coherent_store rqf
 pushq memCmd MEM_CMD_RD addr=req lce=req wp=1
 popq lceReq
 bi ready
-coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1
+coherent_store: pushq memCmd MEM_CMD_WR addr=req lce=req wp=1 src=lcereqdata
 bi ready
 


### PR DESCRIPTION
This change uses the src field of the pushq instruction for mem_fwd messages to tell the hardware which queue (LCE Req or LCE Resp) the mem_fwd should take data from.